### PR TITLE
fix: boot"loop" issue on 3.19

### DIFF
--- a/rmpp_entware.sh
+++ b/rmpp_entware.sh
@@ -420,10 +420,12 @@ mkdir -p /opt /home/root/.entware
 # Create systemd mount unit for /opt
 cat >/etc/systemd/system/opt.mount <<EOF
 [Unit]
-Description=Bind mount for /opt to extend Entware storage
+Description=Bind mount over /opt to give Entware more space
 DefaultDependencies=no
 Conflicts=umount.target
-Before=local-fs.target umount.target
+After=home.mount
+Requires=home.mount
+BindsTo=home.mount
 
 [Mount]
 What=/home/root/.entware
@@ -432,7 +434,7 @@ Type=none
 Options=bind
 
 [Install]
-WantedBy=local-fs.target
+WantedBy=multi-user.target
 EOF
 
 systemctl daemon-reload

--- a/rmpp_entware.sh
+++ b/rmpp_entware.sh
@@ -270,7 +270,9 @@ reenable_entware() {
 Description=Bind mount over /opt to give Entware more space
 DefaultDependencies=no
 Conflicts=umount.target
-Before=local-fs.target umount.target
+After=home.mount
+Requires=home.mount
+BindsTo=home.mount
 
 [Mount]
 What=/home/root/.entware
@@ -279,7 +281,7 @@ Type=none
 Options=bind
 
 [Install]
-WantedBy=local-fs.target
+WantedBy=multi-user.target
 EOF
 
     # Reload systemd configuration


### PR DESCRIPTION
The current mount unit file causes boot"loop" on 3.19 ("loop" because the failsafe kicks in eventually)
This change fixes the issue.